### PR TITLE
fix(foxy): Fix PHP `8.5` deprecation of `setAccessible()` in `ReflectionProperty` class.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,33 +1,22 @@
+---
 on:
-  pull_request:
+  pull_request: &ignore-paths
     paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-      - 'CHANGELOG.md'
-      - '.gitignore'
-      - '.gitattributes'
-      - 'infection.json.dist'
-      - 'psalm.xml'
+      - ".gitattributes"
+      - ".gitignore"
+      - "CHANGELOG.md"
+      - "docs/**"
+      - "README.md"
 
-  push:
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-      - 'CHANGELOG.md'
-      - '.gitignore'
-      - '.gitattributes'
-      - 'infection.json.dist'
-      - 'psalm.xml'
+  push: *ignore-paths
 
 name: build
 
+permissions:
+  contents: read
+
 jobs:
   phpunit:
-    uses: php-forge/actions/.github/workflows/phpunit.yml@main
+    uses: yii2-framework/actions/.github/workflows/phpunit.yml@main
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    with:
-      os: >-
-        ['ubuntu-latest', 'windows-latest']
-      php-version: >-
-        ['8.1', '8.2', '8.3', '8.4']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Change Log
 - Bug #111: Throw `RuntimeException` class on asset/json `I/O` failures (@terabytesoftw)
 - Bug #112: Update `README.md` and add development and testing documentation (@terabytesoftw)
 - Bug #113: Fix PHP `8.4` nullable type deprecation warnings in tests (@terabytesoftw)
-- Bug #114: Fix PHP `8.5` deprecation `setAccessible()` in `ReflectionProperty` class (@terabytesoftw)
+- Bug #114: Fix PHP `8.5` deprecation of `setAccessible()` in `ReflectionProperty` class (`@terabytesoftw`)
 
 ## 0.1.2 June 10, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Change Log
 - Bug #110: Preserve nested empty arrays when rewriting `package.json` (@terabytesoftw)
 - Bug #111: Throw `RuntimeException` class on asset/json `I/O` failures (@terabytesoftw)
 - Bug #112: Fix PHP `8.4` nullable type deprecation warnings in tests (@terabytesoftw)
-
+- Bug #113: Fix PHP `8.5` deprecation `setAccessible()` in `ReflectionProperty` class (@terabytesoftw)
 
 ## 0.1.2 June 10, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Change Log
 - Bug #109: Respect `root-package-json-dir` for `package.json` read/write (@terabytesoftw)
 - Bug #110: Preserve nested empty arrays when rewriting `package.json` (@terabytesoftw)
 - Bug #111: Throw `RuntimeException` class on asset/json `I/O` failures (@terabytesoftw)
-- Bug #112: Fix PHP `8.4` nullable type deprecation warnings in tests (@terabytesoftw)
-- Bug #113: Fix PHP `8.5` deprecation `setAccessible()` in `ReflectionProperty` class (@terabytesoftw)
+- Bug #112: Update `README.md` and add development and testing documentation (@terabytesoftw)
+- Bug #113: Fix PHP `8.4` nullable type deprecation warnings in tests (@terabytesoftw)
+- Bug #114: Fix PHP `8.5` deprecation `setAccessible()` in `ReflectionProperty` class (@terabytesoftw)
 
 ## 0.1.2 June 10, 2024
 

--- a/src/Util/ConsoleUtil.php
+++ b/src/Util/ConsoleUtil.php
@@ -18,6 +18,8 @@ use Composer\IO\IOInterface;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 
+use const PHP_VERSION_ID;
+
 /**
  * Helper for console.
  *
@@ -36,7 +38,11 @@ final class ConsoleUtil
 
         if ($ref->hasProperty('input')) {
             $prop = $ref->getProperty('input');
-            $prop->setAccessible(true);
+
+            if (PHP_VERSION_ID < 80500) {
+                $prop->setAccessible(true);
+            }
+
             $input = $prop->getValue($io);
 
             if ($input instanceof InputInterface) {

--- a/tests/FoxyTest.php
+++ b/tests/FoxyTest.php
@@ -194,7 +194,7 @@ final class FoxyTest extends \PHPUnit\Framework\TestCase
             $foxy->activate($this->composer, $this->io);
 
             $assetFallbackProperty = $foxyReflection->getProperty('assetFallback');
-            
+
             if (PHP_VERSION_ID < 80500) {
                 $assetFallbackProperty->setAccessible(true);
             }

--- a/tests/FoxyTest.php
+++ b/tests/FoxyTest.php
@@ -147,16 +147,19 @@ final class FoxyTest extends \PHPUnit\Framework\TestCase
 
         $foxyReflection = new \ReflectionClass($foxy);
         $assetFallbackProperty = $foxyReflection->getProperty('assetFallback');
-        if (\PHP_VERSION_ID < 80500) {
+
+        if (PHP_VERSION_ID < 80500) {
             $assetFallbackProperty->setAccessible(true);
         }
+
         $assetFallback = $assetFallbackProperty->getValue($foxy);
 
         $this->assertInstanceOf(\Foxy\Fallback\AssetFallback::class, $assetFallback);
 
         $fallbackReflection = new \ReflectionClass($assetFallback);
         $pathProperty = $fallbackReflection->getProperty('path');
-        if (\PHP_VERSION_ID < 80500) {
+
+        if (PHP_VERSION_ID < 80500) {
             $pathProperty->setAccessible(true);
         }
 
@@ -191,6 +194,7 @@ final class FoxyTest extends \PHPUnit\Framework\TestCase
             $foxy->activate($this->composer, $this->io);
 
             $assetFallbackProperty = $foxyReflection->getProperty('assetFallback');
+            
             if (PHP_VERSION_ID < 80500) {
                 $assetFallbackProperty->setAccessible(true);
             }

--- a/tests/FoxyTest.php
+++ b/tests/FoxyTest.php
@@ -28,6 +28,8 @@ use Foxy\Solver\SolverInterface;
 use Foxy\Tests\Fixtures\Asset\StubAssetManager;
 use PHPUnit\Framework\MockObject\MockObject;
 
+use const PHP_VERSION_ID;
+
 final class FoxyTest extends \PHPUnit\Framework\TestCase
 {
     private Composer|MockObject $composer;
@@ -145,14 +147,18 @@ final class FoxyTest extends \PHPUnit\Framework\TestCase
 
         $foxyReflection = new \ReflectionClass($foxy);
         $assetFallbackProperty = $foxyReflection->getProperty('assetFallback');
-        $assetFallbackProperty->setAccessible(true);
+        if (\PHP_VERSION_ID < 80500) {
+            $assetFallbackProperty->setAccessible(true);
+        }
         $assetFallback = $assetFallbackProperty->getValue($foxy);
 
         $this->assertInstanceOf(\Foxy\Fallback\AssetFallback::class, $assetFallback);
 
         $fallbackReflection = new \ReflectionClass($assetFallback);
         $pathProperty = $fallbackReflection->getProperty('path');
-        $pathProperty->setAccessible(true);
+        if (\PHP_VERSION_ID < 80500) {
+            $pathProperty->setAccessible(true);
+        }
 
         $expectedPath = rtrim((string) \getcwd(), '/\\')
             . DIRECTORY_SEPARATOR
@@ -172,7 +178,11 @@ final class FoxyTest extends \PHPUnit\Framework\TestCase
 
         $foxyReflection = new \ReflectionClass(Foxy::class);
         $assetManagersProperty = $foxyReflection->getProperty('assetManagers');
-        $assetManagersProperty->setAccessible(true);
+
+        if (PHP_VERSION_ID < 80500) {
+            $assetManagersProperty->setAccessible(true);
+        }
+
         $originalAssetManagers = $assetManagersProperty->getValue();
         $assetManagersProperty->setValue(null, [StubAssetManager::class]);
 
@@ -181,12 +191,19 @@ final class FoxyTest extends \PHPUnit\Framework\TestCase
             $foxy->activate($this->composer, $this->io);
 
             $assetFallbackProperty = $foxyReflection->getProperty('assetFallback');
-            $assetFallbackProperty->setAccessible(true);
+            if (PHP_VERSION_ID < 80500) {
+                $assetFallbackProperty->setAccessible(true);
+            }
+
             $assetFallback = $assetFallbackProperty->getValue($foxy);
 
             $fallbackReflection = new \ReflectionClass($assetFallback);
+
             $pathProperty = $fallbackReflection->getProperty('path');
-            $pathProperty->setAccessible(true);
+
+            if (PHP_VERSION_ID < 80500) {
+                $pathProperty->setAccessible(true);
+            }
 
             $this->assertSame('stub-package.json', $pathProperty->getValue($assetFallback));
         } finally {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
